### PR TITLE
リリースのCDのテスト

### DIFF
--- a/.github/workflows/release_test.yaml
+++ b/.github/workflows/release_test.yaml
@@ -1,0 +1,29 @@
+name: Publish test Test PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  Publish:
+    name: Build and publish to Test PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry self add "poetry-dynamic-versioning[plugin]"
+      - name: PyPI settings
+        run: |
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_API_TOKEN }}
+      - name: Build and publish via Poetry
+        run: |
+          poetry build
+          poetry publish -r testpypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,12 @@
 [tool.poetry]
 name = "hojichar"
-version = "0.2.0"
+version = "0.0.0" # Versioning by git tag dinamically with https://github.com/mtkennerly/poetry-dynamic-versioning
 description = "Text preprocessing management system."
 license = "Apache-2.0"
 authors = ["kenta.shinzato <hoppiece@gmail.com>"]
+readme = "README.md"
+homepage = "https://github.com/HojiChar/HojiChar"
+repository = "https://github.com/HojiChar/HojiChar"
 
 [tool.poetry.dependencies]
 python = "^3.8"
@@ -33,8 +36,8 @@ pytest-cov = "^4.0.0"
 taskipy = "^1.10.3"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.black]
 line-length = 99
@@ -50,3 +53,8 @@ ignore_missing_imports = true
 lint = "flake8 --show-source hojichar/ tests/ && isort --check-only --diff hojichar/ tests/"
 format = "black hojichar/ tests/ && isort hojichar/ tests"
 test = "pytest . --doctest-modules && mypy ."
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "semver"


### PR DESCRIPTION
## 概要
Semantic Versioning でタグ付けされた commit が リリースされるとパッケージビルド・Test PyPI への登録が自動で行われるようにする
- Actions + poetry + git tag

### リリース手順
1. (基本的には main branch で) `git tag -a <semvar> -m "<コメント>" `でタグ付け. `<semvar>` は 1.2.3 みたいなやつです。
2. `git push origin <semvar>` タグがリモートに反映
3. GitHub の UI からタグ付きコミットをリリース


### 技術的コメント
- バージョン情報をハードコーディングしたくない。バージョニングは、バージョニングツール git (git tag)で行いたい。
- ビルド・デプロイを poetry で行いたい。
- poetry は `pyproject.toml` にバージョン情報をハードコードする必要があるが、これを [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning) という Poetry plugin により git tag 読み込んで 動的に デプロイ時のバージョン情報に含めてくれるようにしている