### PR TITLE
fix poetry versioning semvar -> pep440

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,4 @@ test = "pytest . --doctest-modules && mypy ."
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
-style = "semver"
+style = "pep440"


### PR DESCRIPTION
バージョンの前に小文字の `v`が必要そう
```
The pattern did not match any tags

Pattern:
(?x)                                                        (?# ignore whitespace)
    ^v((?P<epoch>\d+)!)?(?P<base>\d+(\.\d+)*)                   (?# v1.2.3 or v1!2000.1.2)
    ([-._]?((?P<stage>[a-zA-Z]+)[-._]?(?P<revision>\d+)?))?     (?# b0)
    (\+(?P<tagged_metadata>.+))?$                               (?# +linux)

Tags:
['0.2.0']
```