### PR TITLE
Fix confliction agains branch protection rule

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,13 +1,9 @@
 name: Deploy documents
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   GenenerateDocs:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![CI wowkflow](https://github.com/HojiChar/HojiChar/actions/workflows/ci.yaml/badge.svg)](https://github.com/HojiChar/HojiChar/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/HojiChar/HojiChar/branch/main/graph/badge.svg?token=16928I9U9Y)](https://codecov.io/gh/HojiChar/HojiChar)
 
+[Documentation](https://hojichar.github.io/HojiChar/hojichar.html)
+
 ## 概要
 HojiChar はテキストデータの前処理のためのPythonモジュールです. 言語モデル構築時などにコーパスを前処理する目的で開発されました。
 


### PR DESCRIPTION
The workflow to generate documents on push to the main branch was in conflict with the protection rules of the main branch, so documents were generated only on an update of pull requests.