### PR TITLE
Update Docs Generation Workflow to Push to 'docs' Branch

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions: write-all

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Check if docs branch exists
         id: check_docs_branch
         run: |
-          git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
+          git remote set-url origin https://github-actions:${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}
           git fetch origin
           if ! git show-ref --quiet refs/remotes/origin/docs; then
             echo "::set-output name=branch_exists::false"

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -35,17 +35,9 @@ jobs:
           git remote set-url origin https://github-actions:${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}
           git fetch origin
           if ! git show-ref --quiet refs/remotes/origin/docs; then
-            echo "::set-output name=branch_exists::false"
-          else
-            echo "::set-output name=branch_exists::true"
+            echo "Create docs branch"; \
+            exit 1; \
           fi
-
-      - name: Create docs branch if not exists
-        if: steps.check_docs_branch.outputs.branch_exists == 'false'
-        run: |
-          git remote set-url origin https://github-actions:${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}
-          git checkout -b docs
-          git push -u origin docs
 
       - name: Push new docs
         run: |

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -28,13 +28,32 @@ jobs:
       - name: Document generation
         run: |
           pdoc -o docs hojichar
+
+      - name: Check if docs branch exists
+        id: check_docs_branch
+        run: |
+          git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
+          git fetch origin
+          if ! git show-ref --quiet refs/remotes/origin/docs; then
+            echo "::set-output name=branch_exists::false"
+          else
+            echo "::set-output name=branch_exists::true"
+          fi
+
+      - name: Create docs branch if not exists
+        if: steps.check_docs_branch.outputs.branch_exists == 'false'
+        run: |
+          git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
+          git checkout -b docs
+          git push -u origin docs
+
       - name: Push new docs
         run: |
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          if (git diff --shortstat | grep '[0-9]'); then \
+          if (git diff --shortstat origin/docs | grep '[0-9]'); then \
             git add .; \
             git commit -m "Generating docs via GitHub Actions"; \
-            git push origin HEAD:${GITHUB_REF}; \
+            git push origin --force HEAD:docs; \
           fi

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -9,6 +9,8 @@ on:
       - main
   workflow_dispatch:
 
+permissions: write-all
+
 jobs:
   GenenerateDocs:
     name: Deploy documents
@@ -32,7 +34,7 @@ jobs:
       - name: Check if docs branch exists
         id: check_docs_branch
         run: |
-          git remote set-url origin https://github-actions:${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}
+          git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git fetch origin
           if ! git show-ref --quiet refs/remotes/origin/docs; then
             echo "Create docs branch"; \
@@ -41,7 +43,7 @@ jobs:
 
       - name: Push new docs
         run: |
-          git remote set-url origin https://github-actions:${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}
+          git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           if (git diff --shortstat origin/docs | grep '[0-9]'); then \

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -43,13 +43,13 @@ jobs:
       - name: Create docs branch if not exists
         if: steps.check_docs_branch.outputs.branch_exists == 'false'
         run: |
-          git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
+          git remote set-url origin https://github-actions:${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}
           git checkout -b docs
           git push -u origin docs
 
       - name: Push new docs
         run: |
-          git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
+          git remote set-url origin https://github-actions:${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}@github.com/${GITHUB_REPOSITORY}
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           if (git diff --shortstat origin/docs | grep '[0-9]'); then \

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![codecov](https://codecov.io/gh/HojiChar/HojiChar/branch/main/graph/badge.svg?token=16928I9U9Y)](https://codecov.io/gh/HojiChar/HojiChar)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/hojichar)
 
+Official docs: https://hojichar.github.io/HojiChar/hojichar.html
+
 ## 概要
 HojiChar はテキストデータの前処理のためのPythonモジュールです. 言語モデル構築時などにコーパスを前処理する目的で開発されました。
 


### PR DESCRIPTION
This PR updates the GitHub Actions workflow responsible for generating and pushing documentation. The updated workflow now pushes the generated documentation to a separate 'docs' branch instead of directly to the main branch. This change addresses the issue with the Branch Protection rule that prevents direct commits to the main branch without a Pull request.

The main changes in this PR include:
- Fetching the 'docs' branch before checking for documentation updates.
- Comparing the current branch with the 'docs' branch to identify any differences.
- Pushing documentation updates to the 'docs' branch instead of the main branch.
- Force pushing the changes to the 'docs' branch as it's considered read-only and not used for development.

This update ensures that the workflow complies with the Branch Protection rules and keeps the main branch clean from direct documentation updates.
