### PR TITLE
Feature/reject reason

### DIFF
--- a/hojichar/core/composition.py
+++ b/hojichar/core/composition.py
@@ -87,7 +87,7 @@ class Compose(Filter):
             document = self._apply_filter(filt=filt, document=document)
             document = inspector.apply(document)
             if (not previous_inspector.is_rejected) and inspector.is_rejected:
-                document.reject_reason = filt.get_jsonalbe_vars()
+                document.reject_reason = filt.get_jsonalbe_vars(exclude_keys={"skip_rejected"})
             previous_inspector = inspector
 
         self._statistics.update_changes(document, self.before_process_inspector, self.inspectors)

--- a/hojichar/core/filter_interface.py
+++ b/hojichar/core/filter_interface.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional, Set
 
 from hojichar.core.models import Document, Token
 
@@ -90,13 +90,14 @@ class Filter:
         document = self.apply(document)
         return document.text
 
-    def get_jsonalbe_vars(self) -> dict:
+    def get_jsonalbe_vars(self, exclude_keys: Optional[Set[str]] = None) -> dict:
         """
         Get the member variable of this filter.
         Eligible variables are primitive types; [bool, int, float, str, None],
         and the name of the variable not starts with the underscore; `_`.
         """
-        exclude_keys = {"logger", "skip_rejected"}
+        if exclude_keys is None:
+            exclude_keys = set()
         return {
             k: v
             for k, v in vars(self).items()
@@ -139,13 +140,14 @@ class TokenFilter:
         exclude_keys = ["logger"]
         return dict(filter(lambda item: item[0] not in exclude_keys, vars(self).items()))
 
-    def get_jsonalbe_vars(self) -> dict:
+    def get_jsonalbe_vars(self, exclude_keys: Optional[Set[str]] = None) -> dict:
         """
         Get the member variable of this filter.
         Eligible variables are primitive types; [bool, int, float, str, None],
         and the name of the variable not starts with the underscore; `_`.
         """
-        exclude_keys = {"logger", "skip_rejected"}
+        if exclude_keys is None:
+            exclude_keys = set()
         return {
             k: v
             for k, v in vars(self).items()

--- a/hojichar/core/filter_interface.py
+++ b/hojichar/core/filter_interface.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, Set
+from typing import Any, Dict, Optional, Set
 
 from hojichar.core.models import Document, Token
 
@@ -90,7 +90,7 @@ class Filter:
         document = self.apply(document)
         return document.text
 
-    def get_jsonalbe_vars(self, exclude_keys: Optional[Set[str]] = None) -> dict:
+    def get_jsonalbe_vars(self, exclude_keys: Optional[Set[str]] = None) -> Dict[str, Any]:
         """
         Get the member variable of this filter.
         Eligible variables are primitive types; [bool, int, float, str, None],

--- a/hojichar/core/inspection.py
+++ b/hojichar/core/inspection.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 import time
-from typing import Any, List, Union
+from typing import Any, Dict, List, Union
 
 from hojichar.core.filter_interface import Filter, TokenFilter
 from hojichar.core.models import Document
@@ -125,7 +125,7 @@ class StatisticsCounter:
         about_layers = []
         for idx, (filter_name, stats) in enumerate(self.counts.items()):
             # about_layers[key] = self.counts[key].get_human_readable_values()
-            item = dict()
+            item: Dict[str, Any] = dict()
             item["name"] = filter_name
             stats = self.counts[filter_name]
             for key, stat in stats.get_human_readable_values().items():

--- a/hojichar/core/inspection.py
+++ b/hojichar/core/inspection.py
@@ -73,6 +73,7 @@ class DocStatistics:
 class StatisticsCounter:
     def __init__(self, inspectors: List[Inspector]) -> None:
         counts = dict()
+        self.inspectors = inspectors
         for inspector in inspectors:
             counts[inspector.target] = FilterStatistics()
         self.counts = counts
@@ -122,13 +123,14 @@ class StatisticsCounter:
     def get_statistics(self) -> dict:
         # about_layers = dict()
         about_layers = []
-        for filter_name, stats in self.counts.items():
+        for idx, (filter_name, stats) in enumerate(self.counts.items()):
             # about_layers[key] = self.counts[key].get_human_readable_values()
             item = dict()
             item["name"] = filter_name
             stats = self.counts[filter_name]
             for key, stat in stats.get_human_readable_values().items():
                 item[key] = stat
+            item["params"] = self.inspectors[idx].target_filter.get_jsonalbe_vars()
             about_layers.append(item)
 
         return {

--- a/hojichar/core/inspection.py
+++ b/hojichar/core/inspection.py
@@ -1,20 +1,23 @@
 import dataclasses
 import logging
 import time
-from typing import Any, List
+from typing import Any, List, Union
 
-from hojichar.core.filter_interface import Filter
+from hojichar.core.filter_interface import Filter, TokenFilter
 from hojichar.core.models import Document
 
 logger = logging.getLogger(__name__)
 
 
 class Inspector(Filter):
-    def __init__(self, target: str, ignore_filtered: bool, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, target_filter: Union[Filter, TokenFilter], filter_idx: int, *args: Any, **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.logger = logging.getLogger("hojichar.Inspector")
-        self.target = target
-        self.ignore_filtered = ignore_filtered
+        self.target_filter = target_filter
+        self.filter_idx = filter_idx
+        self.target = f"{filter_idx}-{target_filter.name}"
 
         self.is_rejected = False
         self.text_hash = 0
@@ -22,8 +25,6 @@ class Inspector(Filter):
 
     def apply(self, document: Document) -> Document:
         self.inspect(document)
-        if not self.ignore_filtered:
-            document.is_rejected = False
         return document
 
     def inspect(self, document: Document) -> None:
@@ -70,13 +71,12 @@ class DocStatistics:
 
 
 class StatisticsCounter:
-    def __init__(self, inspectors: List[Inspector], ignore_filtered: bool) -> None:
+    def __init__(self, inspectors: List[Inspector]) -> None:
         counts = dict()
         for inspector in inspectors:
             counts[inspector.target] = FilterStatistics()
         self.counts = counts
         self.doc_counts = DocStatistics()
-        self.ignore_filtered = ignore_filtered
 
     def update_changes(
         self,
@@ -85,29 +85,20 @@ class StatisticsCounter:
         inspectors: List[Inspector],
     ) -> None:
 
+        # Counting statistics for each filter
         previous_inspector = before_process_inspector
         for idx, inspector in enumerate(inspectors):
-            # logging how many docs are discarded in each filter.
-            if self.ignore_filtered:
-                if (not previous_inspector.is_rejected) and inspector.is_rejected:
-                    self.counts[inspector.target].discard_num += 1
-            else:
-                if inspector.is_rejected:
-                    self.counts[inspector.target].discard_num += 1
+            # Logging how many docs are discarded in each filter
+            if (not previous_inspector.is_rejected) and inspector.is_rejected:
+                self.counts[inspector.target].discard_num += 1
 
             # logging how much volume of docs are changed in each filter.
-            if self.ignore_filtered:
-                if (not previous_inspector.is_rejected) and inspector.is_rejected:
-                    diff_bytes = -inspector.bytes
-                elif previous_inspector.is_rejected and inspector.is_rejected:
-                    diff_bytes = 0
-                else:
-                    diff_bytes = inspector.bytes - previous_inspector.bytes
+            if (not previous_inspector.is_rejected) and inspector.is_rejected:
+                diff_bytes = -inspector.bytes
+            elif previous_inspector.is_rejected and inspector.is_rejected:
+                diff_bytes = 0
             else:
-                if inspector.is_rejected:
-                    diff_bytes = -inspector.bytes
-                else:
-                    diff_bytes = inspector.bytes - previous_inspector.bytes
+                diff_bytes = inspector.bytes - previous_inspector.bytes
 
             self.counts[inspector.target].diff_bytes += diff_bytes
 
@@ -116,12 +107,15 @@ class StatisticsCounter:
 
             previous_inspector = inspector
 
+        # Counting total statistics
         self.doc_counts.processed_num += 1
         self.doc_counts.discard_num += (
             1 if sum([inspector.is_rejected for inspector in inspectors]) > 0 else 0
         )
         self.doc_counts.input_bytes += len(document.original.encode("utf-8"))
-        self.doc_counts.output_bytes += len(document.text.encode("utf-8"))
+        self.doc_counts.output_bytes += (
+            0 if document.is_rejected else len(document.text.encode("utf-8"))
+        )
         self.doc_counts.cumulative_time_ns += inspectors[-1].time_ns - inspectors[0].time_ns
         self.doc_counts.total_token_num += len(document.tokens)
 

--- a/hojichar/core/models.py
+++ b/hojichar/core/models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 
 class Token:
@@ -11,6 +11,9 @@ class Token:
     def original(self) -> str:
         return self.__original
 
+    def __str__(self) -> str:
+        return self.text
+
 
 class Document:
     def __init__(
@@ -19,11 +22,11 @@ class Document:
         self.text = text
         self.__original = text
         self.is_rejected = is_rejected
-        self.processed_text = ""
         if tokens is None:
             self.tokens: List[Token] = []
 
         self.dedup_lsh: List[str] = []
+        self.reject_reason: Dict[str, Any] = {}
 
     @property
     def original(self) -> str:
@@ -34,3 +37,6 @@ class Document:
 
     def get_tokens(self) -> List[str]:
         return [token.text for token in self.tokens]
+
+    def __str__(self) -> str:
+        return self.text

--- a/hojichar/filters/document_filters.py
+++ b/hojichar/filters/document_filters.py
@@ -165,9 +165,26 @@ class JSONLoader(Filter):
 
 class JSONDumper(Filter):
     """
-    Doucment.text の値を, エントリ名が "text" という名前の Json に格納します.
-    出力が json lines 欲しいときに Compose の出力前に使用します.
+    Document.text の文字列を json に変換します.
+    必要に応じ Document のメタデータを付与します.
     """
+
+    def __init__(
+        self,
+        dump_reason: bool = False,
+        p: float = 1,
+        skip_rejected: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Args:
+            dump_reason (bool, optional): `is_rejected`, `reason` エントリをダンプします. Defaults to False.
+            p (float, optional): Apply probability. Defaults to 1.
+            skip_rejected (bool, optional): 破棄済みサンプルを排除しません.
+        """
+        super().__init__(p, skip_rejected, *args, **kwargs)
+        self.dump_reason = dump_reason
 
     def apply(self, document: Document) -> Document:
         """
@@ -175,7 +192,17 @@ class JSONDumper(Filter):
         '{"text": "hojichar"}'
         """
         text = document.text
-        document.text = json.dumps({"text": text}, ensure_ascii=False)
+        if self.dump_reason:
+            document.text = json.dumps(
+                {
+                    "text": text,
+                    "is_rejected": document.is_rejected,
+                    "reason": document.reject_reason,
+                },
+                ensure_ascii=False,
+            )
+        else:
+            document.text = json.dumps({"text": text}, ensure_ascii=False)
         return document
 
 

--- a/hojichar/utils/process.py
+++ b/hojichar/utils/process.py
@@ -13,21 +13,23 @@ def process_iter(
     filter: hojichar.Compose,
     exit_on_error: bool,
     stdout_fp: Optional[TextIO] = None,
-) -> Iterator[str]:
+) -> Iterator[hojichar.Document]:
     """
     Getting an iterator of string, processing by given hojichar.Compose filter,
     and iterate processed string.
+    Standard output of each filter is redirected to stdout_fp. Default is /dev/null.
 
     Args:
         input_iter (Iterator[str]): Input iterator.
         filter (hojichar.Compose): Processing filter.
         exit_on_error (bool): Halt with error while processing.
+        stdout_fp: Redirection of stdout in each filter.
 
     Raises:
         e: Exception raised during processing in hojichar.Compose
 
     Yields:
-        Iterator[str]: Processed text
+        Iterator[hojichar.Document]: Processed text
     """
     if stdout_fp is None:
         stdout_fp = open(os.devnull, "w")
@@ -35,11 +37,27 @@ def process_iter(
         for line in input_iter:
             try:
                 doc = filter.apply(hojichar.Document(line))
-                if not doc.is_rejected:
-                    yield doc.text
+                yield doc
             except Exception as e:
                 if exit_on_error:
                     raise e
                 else:
                     logger.error(f"Caught {type(e)}. Skip processing the line: `{line}`")
                     continue
+
+
+def reject_iter(input_iter: Iterator[hojichar.Document], discard_rejected: bool) -> Iterator[str]:
+    """_summary_
+
+    Args:
+        input_iter (Iterator[hojichar.Document]): Input iterator of the documents.
+        discard_rejected (bool): Whether discarding `is_rejected` docs or not.
+
+    Yields:
+        Iterator[str]: Output iterator of the string.
+    """
+    for doc in input_iter:
+        if doc.is_rejected and discard_rejected:
+            pass
+        else:
+            yield doc.text

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -12,40 +12,21 @@ class TestCompose:
         assert cleaner("") == "<hojichar><hojichar>"
 
     def test_discard_num_ignore_filtered_option_positive_case(self):
-        cleaner = Compose([DiscardAll(), DiscardAll()], ignore_filtered=True)
+        cleaner = Compose([DiscardAll(), DiscardAll()])
         cleaner("hoge")
         counts = cleaner._statistics.counts
         assert counts["0-DiscardAll"].discard_num == 1
         assert counts["1-DiscardAll"].discard_num == 0
 
-    def test_discard_num_ignore_filtered_option_negative_case(self):
-        cleaner = Compose([DiscardAll(), DiscardAll()], ignore_filtered=False)
-        cleaner("hoge")
-        counts = cleaner._statistics.counts
-        assert counts["0-DiscardAll"].discard_num == 1
-        assert counts["1-DiscardAll"].discard_num == 1
-
     def test_diff_bytes_ingore_filtered_option_positive_case(self):
         cleaner = Compose(
             [Identity(), DiscardAll(), ExampleHojiChar()],
-            ignore_filtered=True,
         )
         cleaner("a")
         counts = cleaner._statistics.counts
         assert counts["0-Identity"].diff_bytes == 0
         assert counts["1-DiscardAll"].diff_bytes == -1
         assert counts["2-ExampleHojiChar"].diff_bytes == 0
-
-    def test_diff_bytes_ingore_filtered_option_negative_case(self):
-        cleaner = Compose(
-            [Identity(), DiscardAll(), ExampleHojiChar()],
-            ignore_filtered=False,
-        )
-        cleaner("a")
-        counts = cleaner._statistics.counts
-        assert counts["0-Identity"].diff_bytes == 0
-        assert counts["1-DiscardAll"].diff_bytes == -1
-        assert counts["2-ExampleHojiChar"].diff_bytes == 10
 
     def test_random_apply1(self):
         cleaner = Compose([DiscardAll(p=0.1)], random_state=42)

--- a/tests/utils/test_process.py
+++ b/tests/utils/test_process.py
@@ -1,7 +1,7 @@
 import pytest
 
 import hojichar
-from hojichar.utils.process import process_iter
+from hojichar.utils.process import process_iter, reject_iter
 
 
 class MockExcetion(Exception):
@@ -31,8 +31,9 @@ class MockFilter(hojichar.Filter):
     ],
 )
 def test_process_iter(test_data, expected_output):
-    out_iter = process_iter(test_data, MockFilter(), exit_on_error=False)
-    assert list(out_iter), expected_output
+    doc_iter = process_iter(test_data, MockFilter(), exit_on_error=False)
+    out_iter = reject_iter(doc_iter, discard_rejected=True)
+    assert list(map(str, out_iter)), expected_output
 
 
 @pytest.mark.parametrize(
@@ -43,7 +44,8 @@ def test_process_iter(test_data, expected_output):
     ],
 )
 def test_process_iter_raise(test_data, error):
-    out_iter = process_iter(test_data, MockFilter(), exit_on_error=True)
+    doc_iter = process_iter(test_data, MockFilter(), exit_on_error=True)
+    out_iter = reject_iter(doc_iter, discard_rejected=True)
     assert "Line1" == next(out_iter)
     with pytest.raises(error):
         next(out_iter)


### PR DESCRIPTION
## Major Changes
- The ignore_filtered option in the Compose class has been removed, and instead, the skip_rejected option has been added to the Filter class.
- A function has been added to the Compose class that annotates information about discarded filters to Document when processing text. 
## Background
- By default in HojiChar, each filter of the Compose class is designed to ignore discarded samples. The ignore_filtered was a parameter to control this behavior, but due to this option, statistical processing and the mechanism for discarding samples became overly complex, so it was decided to discontinue this option. On the other hand, the skip_rejected option has been added to the Filter class, which allows filters to execute processing even for samples that have been rejected.
- To research the validity of discarded samples, the metadata of the discarded filter was written into Document.reason at the time of discarding. The metadata includes primitive type (None, bool, int, float, str) member variables of the filter.
- As a result of the above changes, by interposing a JSONDumper class in the final layer of the filter, which is applied even if it has been rejected, it has been modified so that research on rejected samples can be conducted from the CLI.