### PR TITLE
Compose make expand the filter while initialization.

### DIFF
--- a/hojichar/core/composition.py
+++ b/hojichar/core/composition.py
@@ -39,7 +39,7 @@ class Compose(Filter):
             `random_state` must be int or np.random.Generator instance.
         """
         super().__init__(*args, **kwargs)
-        self.filters = filters
+        self.set_filters(filters)
         self.logger = logging.getLogger("hojichar.Compose")
         self.before_process_inspector = Inspector(
             target_filter=BeforeProcessFilter(), filter_idx=-1
@@ -59,6 +59,21 @@ class Compose(Filter):
             self.rng = random_state
         else:
             raise ValueError(f"{random_state} cannot be used to seed.")
+
+    def set_filters(self, filters: List[Union[Filter, TokenFilter]]) -> None:
+        """
+        Set the filter to a Compose object. The filter is expanded if the
+        list of filters in the argument contains a filter bound by Compose.
+
+        Args:
+            filters (List[Union[Filter, TokenFilter]]): Target filters
+        """
+        self.filters: List[Union[Filter, TokenFilter]] = []
+        for filter in filters:
+            if isinstance(filter, Compose):
+                self.filters.extend(filter.filters)
+            else:
+                self.filters.append(filter)
 
     def __call__(self, text: str) -> str:
         document = Document(text)

--- a/tests/core/test_composition.py
+++ b/tests/core/test_composition.py
@@ -51,3 +51,10 @@ class TestCompose:
         assert cleaner.statistics["total_info"]["total_token_num"] == 2
         cleaner("foo hoge")
         assert cleaner.statistics["total_info"]["total_token_num"] == 4
+
+    def test_expand_filters(self):
+        cleaner1 = Compose([ExampleHojiChar(), ExampleHojiChar()])
+        cleaner2 = Compose([ExampleHojiChar(), cleaner1])
+        cleaner2("hello")
+        stats = cleaner2.statistics_obj
+        assert len(stats.layers_info) == 3


### PR DESCRIPTION
## Changes
Fixed a problem in which the `filters` argument of a `Compose` object would display only `Compose` instead of expanding filters bundled by Compose in the statistics if they existed.