### PR TITLE
Feature/file in with pbar

### DIFF
--- a/hojichar/utils/io_iter.py
+++ b/hojichar/utils/io_iter.py
@@ -51,6 +51,6 @@ def stdout_from_iter(iter: Iterator[str]) -> None:
         sys.exit(1)
 
 
-def fileout_from_iter(iter: Iterator[str], fp: TextIO) -> None:
+def fileout_from_iter(fp: TextIO, iter: Iterator[str]) -> None:
     for line in iter:
         fp.write(line + "\n")

--- a/poetry.lock
+++ b/poetry.lock
@@ -71,7 +71,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
@@ -721,6 +721,39 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.65.0"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.65.0-py3-none-any.whl", hash = "sha256:c4f53a17fe37e132815abceec022631be8ffe1b9381c2e6e30aa70edc99e9671"},
+    {file = "tqdm-4.65.0.tar.gz", hash = "sha256:1871fb68a86b8fb3b59ca4cdd3dcccbc7e6d613eeed31f4c332531977b89beb5"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
+name = "types-tqdm"
+version = "4.65.0.2"
+description = "Typing stubs for tqdm"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-tqdm-4.65.0.2.tar.gz", hash = "sha256:ad07ee08e758cad04299543b2586ef1d3fd5a10c54271457de13e0cba009cc5d"},
+    {file = "types_tqdm-4.65.0.2-py3-none-any.whl", hash = "sha256:956d92e921651309ffe36a783cc10d41d753f107c84e82d84373c84d68737246"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.6.3"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -750,4 +783,4 @@ test = ["pytest (>=6.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "97a98665305784e5f133c9896cc4c8c31cff5cf041d64fbe9cbd52b21cb4b0b6"
+content-hash = "d8d640a2246056d75682b123f181d1463dd75144465302f786dde6baad6ed98d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -783,4 +783,4 @@ test = ["pytest (>=6.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "bba7b7e92a46160cd7fc4f1b27d2ebf599b81a96623322e76bdc1d9537d169bf"
+content-hash = "c960cda8f4a4d63768dad1a868918cbd4851abd1f468b3b0eccfcd7f1261b33d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -745,7 +745,7 @@ telegram = ["requests"]
 name = "types-tqdm"
 version = "4.65.0.2"
 description = "Typing stubs for tqdm"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 files = [
@@ -783,4 +783,4 @@ test = ["pytest (>=6.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d8d640a2246056d75682b123f181d1463dd75144465302f786dde6baad6ed98d"
+content-hash = "bba7b7e92a46160cd7fc4f1b27d2ebf599b81a96623322e76bdc1d9537d169bf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ black = "^22.3.0"
 flake8 = "^4.0.1"
 isort = "^5.10.1"
 mypy = "^1.0"
+types-tqdm = "^4.65.0.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.2"
@@ -38,7 +39,6 @@ pytest-cov = "^4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 taskipy = "^1.10.3"
-types-tqdm = "^4.65.0.2"
 
 
 [tool.poetry.group.doc.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ python = "^3.8"
 numpy = ">=1.17.0"
 mmh3 = "^4.0"
 tqdm = "^4.65.0"
-types-tqdm = "^4.65.0.2"
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ hojichar = "hojichar.cli:main"
 python = "^3.8"
 numpy = ">=1.17.0"
 mmh3 = "^4.0"
+tqdm = "^4.65.0"
+types-tqdm = "^4.65.0.2"
 
 [tool.poetry.group.dev]
 optional = true
@@ -37,6 +39,7 @@ pytest-cov = "^4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 taskipy = "^1.10.3"
+types-tqdm = "^4.65.0.2"
 
 
 [tool.poetry.group.doc.dependencies]

--- a/tests/utils/test_io_iter.py
+++ b/tests/utils/test_io_iter.py
@@ -147,5 +147,5 @@ def test_stdout_from_iter(capture_stdout, test_data, expected_output):
 )
 def test_fileout_from_iter(test_data, expected_output):
     fp = io.StringIO()
-    fileout_from_iter(test_data, fp)
+    fileout_from_iter(fp, test_data)
     assert fp.getvalue() == expected_output


### PR DESCRIPTION
## Changes
- Statistics are now displayed during processing. 
  - The number of MB processed is now displayed while redirecting standard output or writing with the `--output` option. 
- Added `--input` option to HojiChar CLI. It takes a file path as an argument and specifies an input file. 
  - A progress bar and the remaining expected time are displayed when this option is used. 
- The `tqdm` has been added to the dependencies for the above changes.