### PR TITLE
Properly set the `lookup_size` attribute in AcceptJapanese initialization

### DIFF
--- a/hojichar/filters/document_filters.py
+++ b/hojichar/filters/document_filters.py
@@ -511,7 +511,7 @@ class AcceptJapanese(Filter):
     def __init__(self, lookup_size: int = 50, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        self.lookup_size = 50
+        self.lookup_size = lookup_size
         self.hiragana_katakana_pat = re.compile(r"[ぁ-んァ-ン]")
 
     def apply(self, doc: Document) -> Document:


### PR DESCRIPTION
## What

This PR addresses an issue where the lookup_size attribute is not correctly initialized in the AcceptJapanese class.

## Environment

- Python 3.11.4
- Hojichar 0.9.0

## Steps to Reproduce

To reproduce the issue:

```python
>>> from hojichar.filters.document_filters import AcceptJapanese
>>> accept_japanese_filter = AcceptJapanese(lookup_size=100)
>>> print(accept_japanese_filter.lookup_size)  # Expected: 100, Actual: 50
50
```

With this PR, the lookup_size attribute will be set as expected during the initialization of the AcceptJapanese class.