### PR TITLE
Add `extras` dict to Document model

### DIFF
--- a/hojichar/core/models.py
+++ b/hojichar/core/models.py
@@ -17,13 +17,16 @@ class Token:
 
 class Document:
     def __init__(
-        self, text: str, is_rejected: bool = False, tokens: Optional[List[Token]] = None
+        self, text: str, is_rejected: bool = False, tokens: Optional[List[Token]] = None, extras: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.text = text
         self.__original = text
         self.is_rejected = is_rejected
         if tokens is None:
             self.tokens: List[Token] = []
+
+        if extras is None:
+            self.extras: Dict[str, Any] = {}
 
         self.dedup_lsh: List[str] = []
         self.reject_reason: Dict[str, Any] = {}

--- a/hojichar/filters/document_filters.py
+++ b/hojichar/filters/document_filters.py
@@ -5,7 +5,7 @@ import re
 import time
 import unicodedata
 from os import PathLike
-from typing import Any, Optional, Union
+from typing import List, Any, Optional, Union
 
 import hojichar
 from hojichar.core.filter_interface import Filter
@@ -127,10 +127,11 @@ class JSONLoader(Filter):
     したドキュメントは破棄されます.
     """
 
-    def __init__(self, key: str = "text", ignore: bool = False, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, key: str = "text", ignore: bool = False, extra_keys: Optional[List[str]] = [], *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.key = key
         self.ignore = ignore
+        self.extra_keys = extra_keys
 
     def apply(self, document: Document) -> Document:
         """
@@ -153,6 +154,7 @@ class JSONLoader(Filter):
         try:
             data = json.loads(document.text)
             document.text = str(data[self.key])
+            document.extras = {key: data[key] for key in self.extra_keys if key in data }
         except Exception as e:
             if self.ignore:
                 document.is_rejected = True

--- a/tests/filters/test_document_filters.py
+++ b/tests/filters/test_document_filters.py
@@ -1,5 +1,5 @@
 from hojichar.core.models import Document
-from hojichar.filters import tokenization
+from hojichar.filters import document_filters, tokenization
 
 
 class TestSentenceTokenizer:
@@ -23,3 +23,18 @@ class TestSentenceTokenizer:
             "ありがとう。",
             "さよなら",
         ] == transfomed_doc.get_tokens()
+
+
+class TestJSONLoader:
+    def test_apply(self):
+        data = '{"text": "おはよう。おやすみ。ありがとう。さよなら。", "url": "https://example.com", "title": "example"}'
+        doc = Document(data)
+        loaded = document_filters.JSONLoader().apply(doc)
+        assert loaded.text == "おはよう。おやすみ。ありがとう。さよなら。"
+        assert loaded.extras == {}
+
+        doc = Document(data)
+        loaded = document_filters.JSONLoader(extra_keys=["url", "title"]).apply(doc)
+        assert loaded.text == "おはよう。おやすみ。ありがとう。さよなら。"
+        assert loaded.extras["url"] == "https://example.com"
+        assert loaded.extras["title"] == "example"


### PR DESCRIPTION
## What

Add the `extras` dict attribute to Document class.
When you use JSONLoader to read json string, you can hold extra keys except `text` and use it in filters later, like rejecting documents depending on those urls, deduplicating documents based on the url.