### PR TITLE
JSONDumper: Exclude '__init_stats' from exported extras in JSON output

### DIFF
--- a/hojichar/filters/document_filters.py
+++ b/hojichar/filters/document_filters.py
@@ -242,10 +242,11 @@ class JSONDumper(Filter):
                 )
         else:
             if self.export_extras:
+                output_extras = {k: v for k, v in document.extras.items() if k != "__init_stats"}
                 document.text = json.dumps(
                     {
                         "text": text,
-                        "extras": document.extras,
+                        "extras": output_extras,
                     },
                     ensure_ascii=False,
                 )


### PR DESCRIPTION
Fixed an issue where the internal statistics counter key was output when the `JSONDumper` class was set to `export_extras`  as True.