### PR TITLE
Preserve document "init stats" outside `extras` and document metadata flow

### DIFF
--- a/hojichar/core/models.py
+++ b/hojichar/core/models.py
@@ -35,6 +35,8 @@ class Document:
         extras (Dict[str, Any]): A dictionary to store additional metadata about the document.
         reject_reason (Dict[str, Any]): A dictionary to store the reason for rejection. The
           filter class and the member name and value will logged at the filter is logged here.
+        initial_stats (Optional[Dict[str, Any]]): Internal copy of the document statistics
+          captured before the pipeline mutates the document.
 
     Next attributes will be deprecated in future versions:
         tokens (List[Token]): A list of tokens extracted from the document.
@@ -61,10 +63,34 @@ class Document:
             self.extras = extras
 
         self.reject_reason: Dict[str, Any] = {}
+        self._initial_stats: Optional[dict[str, Any]] = None
+        if "__init_stats" in self.extras:
+            self._initial_stats = self.extras.pop("__init_stats")
 
     @property
     def original(self) -> str:
         return self.__original
+
+    def _set_initial_stats(self, stats: dict[str, Any]) -> None:
+        """
+        Store the document statistics captured before the pipeline modifies the document.
+        Internal API: not intended for filter implementations.
+        """
+        self._initial_stats = stats
+
+    def _get_initial_stats(self) -> Optional[dict[str, Any]]:
+        """
+        Retrieve the stored initial statistics of the document, if available.
+        Internal API: not intended for filter implementations.
+        """
+        return self._initial_stats
+
+    def _clear_initial_stats(self) -> None:
+        """
+        Remove the stored initial statistics. Useful after the stats are consumed.
+        Internal API: not intended for filter implementations.
+        """
+        self._initial_stats = None
 
     @deprecated_since("1.0.0")
     def set_tokens(self, tokens: List[str]) -> None:

--- a/hojichar/filters/document_filters.py
+++ b/hojichar/filters/document_filters.py
@@ -222,7 +222,7 @@ class JSONDumper(Filter):
         text = document.text
         if self.dump_reason:
             if self.export_extras:
-                output_extras = {k: v for k, v in document.extras.items() if k != "__init_stats"}
+                output_extras = dict(document.extras)
                 document.text = json.dumps(
                     {
                         "text": text,
@@ -243,7 +243,7 @@ class JSONDumper(Filter):
                 )
         else:
             if self.export_extras:
-                output_extras = {k: v for k, v in document.extras.items() if k != "__init_stats"}
+                output_extras = dict(document.extras)
                 document.text = json.dumps(
                     {
                         "text": text,

--- a/tests/filters/test_document_filters.py
+++ b/tests/filters/test_document_filters.py
@@ -1,3 +1,5 @@
+import json
+
 from hojichar.core.models import Document
 from hojichar.filters import document_filters, tokenization
 
@@ -38,3 +40,32 @@ class TestJSONLoader:
         assert loaded.text == "おはよう。おやすみ。ありがとう。さよなら。"
         assert loaded.extras["url"] == "https://example.com"
         assert loaded.extras["title"] == "example"
+
+    def test_apply_loads_embedded_extras(self):
+        data = '{"text": "hello", "extras": {"key1": "val1", "nested": {"foo": "bar"}}}'
+        doc = Document(data)
+        loaded = document_filters.JSONLoader().apply(doc)
+        assert loaded.text == "hello"
+        assert loaded.extras["key1"] == "val1"
+        assert loaded.extras["nested"] == {"foo": "bar"}
+
+    def test_apply_extra_keys_merge_with_existing_extras(self):
+        data = '{"text": "hello", "url": "https://example.com"}'
+        doc = Document(data, extras={"existing": "value"})
+        loaded = document_filters.JSONLoader(extra_keys=["url"]).apply(doc)
+        assert loaded.text == "hello"
+        assert loaded.extras == {"existing": "value", "url": "https://example.com"}
+
+
+class TestJSONDumper:
+    def test_export_extras_roundtrip(self):
+        loader_input = '{"text": "hello", "extras": {"key1": "val1"}}'
+        doc = document_filters.JSONLoader().apply(Document(loader_input))
+        doc.extras["added_in_pipeline"] = 123
+
+        dumped = document_filters.JSONDumper(export_extras=True).apply(doc)
+        payload = json.loads(dumped.text)
+
+        assert payload["text"] == "hello"
+        assert payload["extras"]["key1"] == "val1"
+        assert payload["extras"]["added_in_pipeline"] == 123


### PR DESCRIPTION
## Enhancement of `Document.extras`

- Add a dedicated `_initial_stats` field to `Document`, migrate legacy `extras["__init_stats"]` values, and expose _set/_get/_clear helpers so `Compose` / `AsyncCompose` can manage stats without relying on mutable extras.
- Update Compose/AsyncCompose stream handling to use the new helpers, keep the fallback when stats are missing, and continue clearing stats after aggregation.
- Adjust `JSONDumper` to dump all extras directly (no `__init_stats` filtering) and enhance `JSONLoader` so it merges embedded extras dictionaries or selected `extra_keys` into `Document.extras` instead of overwriting.
- Extend the README and JSONLoader docstring to explain how metadata flows through pipelines via JSONLoader/JSONDumper.
- Add regression tests covering JSONLoader metadata merging and JSONDumper round-tripping.