### PR TITLE
Add ordered output option to `Parallel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ with hojichar.Parallel(cleaner, num_jobs=10) as pfilter:
 
 - Always use the `Parallel` class within a `with` statement.
 - `Parallel.imap_apply(doc_iter)` processes an iterator of `Document` and returns an iterator of the processed documents.
+- By default, processed documents are yielded as soon as they complete. Pass `ordered=True`
+  to `Parallel` to yield them in the same order as the input documents.
 - For additional options and details about the `Parallel` class, please refer to the official documentation.
 
 ## CLI tool and preprocessing profile

--- a/hojichar/core/parallel.py
+++ b/hojichar/core/parallel.py
@@ -60,7 +60,11 @@ class Parallel:
     """
 
     def __init__(
-        self, filter: hojichar.Compose, num_jobs: int | None = None, ignore_errors: bool = False
+        self,
+        filter: hojichar.Compose,
+        num_jobs: int | None = None,
+        ignore_errors: bool = False,
+        ordered: bool = False,
     ):
         """
         Initializes a new instance of the Parallel class.
@@ -80,10 +84,14 @@ class Parallel:
                 stop the processing of further documents. If set to False, the first
                 exception thrown will terminate the entire parallel processing operation.
                 Defaults to False.
+            ordered (bool, optional): If set to True, processed documents are yielded in
+                the same order as the input documents. If set to False, documents are
+                yielded as soon as their processing completes. Defaults to False.
         """
         self.filter = filter
         self.num_jobs = num_jobs
         self.ignore_errors = ignore_errors
+        self.ordered = ordered
 
         self._pool: Pool | None = None
         self._pid_stats: dict[int, List[Statistics]] | None = None
@@ -119,7 +127,12 @@ class Parallel:
                 "Parallel instance not properly initialized. Use within a 'with' statement."
             )
         try:
-            for doc, pid, stat, err_msg in self._pool.imap_unordered(_worker, docs):
+            results = (
+                self._pool.imap(_worker, docs)
+                if self.ordered
+                else self._pool.imap_unordered(_worker, docs)
+            )
+            for doc, pid, stat, err_msg in results:
                 self._pid_stats[pid] = stat
                 if err_msg is not None:
                     logger.error(f"Error in worker {pid}: {err_msg}")

--- a/tests/core/test_paralle.py
+++ b/tests/core/test_paralle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 
 import pytest
 
@@ -31,6 +32,14 @@ class DummyAppendFilter(hojichar.Filter):
         return document
 
 
+class DelayFilter(hojichar.Filter):
+    def apply(self, document: hojichar.Document) -> hojichar.Document:
+        delay, text = document.text.split(":", maxsplit=1)
+        time.sleep(float(delay))
+        document.text = text
+        return document
+
+
 @pytest.mark.parametrize("num_jobs", [1, 4, None])
 def test_processed_docs_count(num_jobs: int | None) -> None:
     documents = [hojichar.Document(json.dumps({"text": f"doc_{i}"})) for i in range(10)]
@@ -49,6 +58,26 @@ def test_processed_docs_equality(num_jobs: int | None) -> None:
     with Parallel(filter, num_jobs=num_jobs) as pfilter:
         processed_docs = list(pfilter.imap_apply(iter(documents)))
         assert set(str(s) for s in processed_docs) == set(str(s) for s in documents)
+
+
+@pytest.mark.parametrize("ordered", [False, True])
+def test_parallel_ordering(ordered: bool) -> None:
+    documents = [
+        hojichar.Document("0.2:slow"),
+        hojichar.Document("0:fast-1"),
+        hojichar.Document("0:fast-2"),
+    ]
+    filter = hojichar.Compose([DelayFilter()])
+
+    with Parallel(filter, num_jobs=3, ordered=ordered) as pfilter:
+        processed_docs = list(pfilter.imap_apply(iter(documents)))
+
+    texts = [doc.text for doc in processed_docs]
+    if ordered:
+        assert texts == ["slow", "fast-1", "fast-2"]
+    else:
+        assert texts[0] != "slow"
+        assert set(texts) == {"slow", "fast-1", "fast-2"}
 
 
 @pytest.mark.parametrize("num_jobs", [1, 4, None])


### PR DESCRIPTION
## Summary

- Add an `ordered` option to `Parallel`
  - Use `Pool.imap` when `ordered=True`
- Preserve the existing unordered behavior by default
- Add tests and documentation for ordered output
